### PR TITLE
Compatibility with doctrine/dbal 2.6.x

### DIFF
--- a/src/DateImmutableType.php
+++ b/src/DateImmutableType.php
@@ -3,6 +3,7 @@
 namespace VasekPurchart\Doctrine\Type\DateTimeImmutable;
 
 use DateTimeImmutable;
+use DateTimeInterface;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
@@ -36,6 +37,28 @@ class DateImmutableType extends \Doctrine\DBAL\Types\DateType
 		}
 
 		return $dateTime;
+	}
+
+	/**
+	 * @param \DateTimeInterface|null $value
+	 * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+	 * @return string
+	 */
+	public function convertToDatabaseValue($value, AbstractPlatform $platform)
+	{
+		if ($value === null) {
+			return $value;
+		}
+
+		if ($value instanceof DateTimeInterface) {
+			return $value->format($platform->getDateFormatString());
+		}
+
+		if (!is_scalar($value)) {
+			$value = sprintf('of type %s', gettype($value));
+		}
+
+		throw \Doctrine\DBAL\Types\ConversionException::conversionFailed($value, $this->getName());
 	}
 
 	/**

--- a/src/DateTimeImmutableType.php
+++ b/src/DateTimeImmutableType.php
@@ -3,6 +3,7 @@
 namespace VasekPurchart\Doctrine\Type\DateTimeImmutable;
 
 use DateTimeImmutable;
+use DateTimeInterface;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
@@ -41,6 +42,28 @@ class DateTimeImmutableType extends \Doctrine\DBAL\Types\DateTimeType
 		}
 
 		return $dateTime;
+	}
+
+	/**
+	 * @param \DateTimeInterface|null $value
+	 * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+	 * @return string
+	 */
+	public function convertToDatabaseValue($value, AbstractPlatform $platform)
+	{
+		if ($value === null) {
+			return $value;
+		}
+
+		if ($value instanceof DateTimeInterface) {
+			return $value->format($platform->getDateTimeFormatString());
+		}
+
+		if (!is_scalar($value)) {
+			$value = sprintf('of type %s', gettype($value));
+		}
+
+		throw \Doctrine\DBAL\Types\ConversionException::conversionFailed($value, $this->getName());
 	}
 
 	/**

--- a/src/DateTimeTzImmutableType.php
+++ b/src/DateTimeTzImmutableType.php
@@ -3,6 +3,7 @@
 namespace VasekPurchart\Doctrine\Type\DateTimeImmutable;
 
 use DateTimeImmutable;
+use DateTimeInterface;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
@@ -36,6 +37,28 @@ class DateTimeTzImmutableType extends \Doctrine\DBAL\Types\DateTimeTzType
 		}
 
 		return $dateTime;
+	}
+
+	/**
+	 * @param \DateTimeInterface|null $value
+	 * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+	 * @return string
+	 */
+	public function convertToDatabaseValue($value, AbstractPlatform $platform)
+	{
+		if ($value === null) {
+			return $value;
+		}
+
+		if ($value instanceof DateTimeInterface) {
+			return $value->format($platform->getDateTimeTzFormatString());
+		}
+
+		if (!is_scalar($value)) {
+			$value = sprintf('of type %s', gettype($value));
+		}
+
+		throw \Doctrine\DBAL\Types\ConversionException::conversionFailed($value, $this->getName());
 	}
 
 	/**

--- a/src/TimeImmutableType.php
+++ b/src/TimeImmutableType.php
@@ -3,6 +3,7 @@
 namespace VasekPurchart\Doctrine\Type\DateTimeImmutable;
 
 use DateTimeImmutable;
+use DateTimeInterface;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
@@ -36,6 +37,28 @@ class TimeImmutableType extends \Doctrine\DBAL\Types\TimeType
 		}
 
 		return $dateTime;
+	}
+
+	/**
+	 * @param \DateTimeInterface|null $value
+	 * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+	 * @return string
+	 */
+	public function convertToDatabaseValue($value, AbstractPlatform $platform)
+	{
+		if ($value === null) {
+			return $value;
+		}
+
+		if ($value instanceof DateTimeInterface) {
+			return $value->format($platform->getTimeFormatString());
+		}
+
+		if (!is_scalar($value)) {
+			$value = sprintf('of type %s', gettype($value));
+		}
+
+		throw \Doctrine\DBAL\Types\ConversionException::conversionFailed($value, $this->getName());
 	}
 
 	/**

--- a/tests/DateTimeImmutableTypesTest.php
+++ b/tests/DateTimeImmutableTypesTest.php
@@ -3,6 +3,7 @@
 namespace VasekPurchart\Doctrine\Type\DateTimeImmutable;
 
 use DateTimeImmutable;
+use stdClass;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type as DoctrineType;
@@ -81,6 +82,42 @@ class DateTimeImmutableTypesTest extends \PHPUnit\Framework\TestCase
 		$platform = $this->getMockForAbstractClass(AbstractPlatform::class);
 		$this->expectException(\Doctrine\DBAL\Types\ConversionException::class);
 		$this->assertNull($type->convertToPHPValue('foobar', $platform));
+	}
+
+	/**
+	 * @dataProvider typesProvider
+	 *
+	 * @param \Doctrine\DBAL\Types\Type $type
+	 */
+	public function testConvertToDatabaseValueWithNull(DoctrineType $type)
+	{
+		$platform = $this->getMockForAbstractClass(AbstractPlatform::class);
+		$this->assertNull($type->convertToDatabaseValue(null, $platform));
+	}
+
+	/**
+	 * @dataProvider typesProvider
+	 *
+	 * @param \Doctrine\DBAL\Types\Type $type
+	 */
+	public function testConvertToDatabaseValueWithString(DoctrineType $type)
+	{
+		$platform = $this->getMockForAbstractClass(AbstractPlatform::class);
+		$this->expectException(\Doctrine\DBAL\Types\ConversionException::class);
+		$type->convertToDatabaseValue('foobar', $platform);
+	}
+
+	/**
+	 * @dataProvider typesProvider
+	 *
+	 * @param \Doctrine\DBAL\Types\Type $type
+	 */
+	public function testConvertToDatabaseValueWithObject(DoctrineType $type)
+	{
+		$platform = $this->getMockForAbstractClass(AbstractPlatform::class);
+		$this->expectException(\Doctrine\DBAL\Types\ConversionException::class);
+		$this->expectExceptionMessage('of type object');
+		$type->convertToDatabaseValue(new stdClass(), $platform);
 	}
 
 	/**


### PR DESCRIPTION
Backwards-compatible fix preparing this library for use with doctrine/dbal 2.6.x. 

Similar approach to what was originally proposed in #7, but using ConversionException::conversionFailed (available in all versions), instead of ConversionException::conversionFailedInvalidType (available only in 2.6). 